### PR TITLE
Add full-text and term level queries specific to Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
+dist: trusty
 sudo: required
 language: node_js
 node_js:
   - 'node'
   - '6'
   - '4'
+env:
+  - ES_VERSION=2.4.3 ES_DOWNLOAD=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.3/elasticsearch-2.4.3.deb
+  - ES_VERSION=5.0.2 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.2.deb
+  - ES_VERSION=5.1.2 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.deb
+  - ES_VERSION=5.2.2 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.2.deb
 addons:
   code_climate:
     repo_token: 'f7898d1d1ca2b76715bc35cc3ba880b35e3fbdc07c3aeb27ca98eecb5e5c064d'
@@ -11,7 +17,7 @@ notifications:
   email: false
 before_install:
   - sudo sysctl vm.max_map_count=262144
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.3/elasticsearch-2.4.3.deb && sudo dpkg -i --force-confnew elasticsearch-2.4.3.deb && sudo service elasticsearch restart
+  - curl -O ${ES_DOWNLOAD} && sudo dpkg -i --force-confnew elasticsearch-${ES_VERSION}.deb && sudo service elasticsearch restart
 before_script:
   - sleep 10
   - npm install -g codeclimate-test-reporter

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ console.log('Feathers app started on 127.0.0.1:3030');
 You can run this example by using `npm start` and going to [localhost:3030/messages](http://localhost:3030/messages).
 You should see an empty array. That's because you don't have any messages yet but you now have full CRUD for your new message service!
 
+## Supported Elasticsearch specific queries
+
+On top of the standard, cross-adapter [queries](http://docs.feathersjs.com/databases/querying.html), feathers-elasticsearch also supports Elasticsearch specific queries.
+
+### $prefix
+Find all documents which have given field containing terms with a specified prefix (not analyzed).
+
+```js
+query: {
+  user: {
+    $prefix: 'bo'
+  }
+}
+```
+
+Read more on the `prefix` query in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html).
+
 ## Supported Elasticsearch versions
 
 feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0 and 5.1. The lowest version supported is 2.4,

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Read more on the `prefix` query in the [Elasticsearch documentation](https://www
 
 ## Supported Elasticsearch versions
 
-feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0 and 5.1. The lowest version supported is 2.4,
+feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0, 5.1 and 5.2. The lowest version supported is 2.4,
 however that does not mean it wouldn't work fine on anything lower than 2.4.
 
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,21 @@ You should see an empty array. That's because you don't have any messages yet bu
 
 On top of the standard, cross-adapter [queries](http://docs.feathersjs.com/databases/querying.html), feathers-elasticsearch also supports Elasticsearch specific queries.
 
+### $match
+Full text query. Find all documents which have given given fields matching the specified value (analysed).
+
+```js
+query: {
+  bio: {
+    $match: 'javascript'
+  }
+}
+```
+
+Read more on the `match` query in the [Elasticsearch documentation](https://https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html).
+
 ### $prefix
-Find all documents which have given field containing terms with a specified prefix (not analyzed).
+Term level query. Find all documents which have given field containing terms with a specified prefix (not analyzed).
 
 ```js
 query: {

--- a/README.md
+++ b/README.md
@@ -140,11 +140,21 @@ query: {
 }
 ```
 
+### $phrase_prefix
+[Full text query `match_phrase_prefix`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html). Find all documents which have given given fields matching the specified phrase prefix (analysed).
+
+```js
+query: {
+  bio: {
+    $phrase_prefix: 'I like JavaS'
+  }
+}
+```
+
 ## Supported Elasticsearch versions
 
-feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0, 5.1 and 5.2. The lowest version supported is 2.4,
-however that does not mean it wouldn't work fine on anything lower than 2.4.
-
+feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0, 5.1 and 5.2. Please note, event though the lowest version supported is 2.4,
+that does not mean it wouldn't work fine on anything lower than 2.4.
 
 ## Quirks
 
@@ -163,7 +173,7 @@ Considering, however that elasticsearch is mainly used to dump data in it and se
 
 ### Full-text search
 
-In the first version of feathers-elasticsearch full texts search has not been implemented yet. It is coming soon. It is very important feature and it sits at the top of my TODO list.
+Currently feathers-elasticsearch supports most important full-text queries in their default form. Elasticsearch search allows additional parameters to be passed to each of those queries for fine-tuning. Those parameters can change behaviour and affect peformance of the queries therefore I believe they should not be exposed to the client. I am considering ways of adding them safely to the queries while retaining flexibility.
 
 ### Performance considerations
 

--- a/README.md
+++ b/README.md
@@ -107,21 +107,8 @@ You should see an empty array. That's because you don't have any messages yet bu
 
 On top of the standard, cross-adapter [queries](http://docs.feathersjs.com/databases/querying.html), feathers-elasticsearch also supports Elasticsearch specific queries.
 
-### $match
-Full text query. Find all documents which have given given fields matching the specified value (analysed).
-
-```js
-query: {
-  bio: {
-    $match: 'javascript'
-  }
-}
-```
-
-Read more on the `match` query in the [Elasticsearch documentation](https://https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html).
-
 ### $prefix
-Term level query. Find all documents which have given field containing terms with a specified prefix (not analyzed).
+[Term level query `prefix`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html). Find all documents which have given field containing terms with a specified prefix (not analyzed).
 
 ```js
 query: {
@@ -131,7 +118,27 @@ query: {
 }
 ```
 
-Read more on the `prefix` query in the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html).
+### $match
+[Full text query `match`]((https://https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html). Find all documents which have given given fields matching the specified value (analysed).
+
+```js
+query: {
+  bio: {
+    $match: 'javascript'
+  }
+}
+```
+
+### $phrase
+[Full text query `match_phrase`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html). Find all documents which have given given fields matching the specified phrase (analysed).
+
+```js
+query: {
+  bio: {
+    $phrase: 'I like JavaScript'
+  }
+}
+```
 
 ## Supported Elasticsearch versions
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ You should see an empty array. That's because you don't have any messages yet bu
 
 On top of the standard, cross-adapter [queries](http://docs.feathersjs.com/databases/querying.html), feathers-elasticsearch also supports Elasticsearch specific queries.
 
+### $all
+[The simplest query `match_all`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html). Find all documents.
+
+```js
+query: {
+  $all: true
+}
+```
+
 ### $prefix
 [Term level query `prefix`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html). Find all documents which have given field containing terms with a specified prefix (not analyzed).
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feathers-elasticsearch",
   "description": "Elasticsearch adapter for FeathersJs",
   "version": "0.1.0",
-  "homepage": "https://github.com/jciolek/feathers-elasticsearch",
+  "homepage": "https://github.com/feathersjs/feathers-elasticsearch",
   "main": "lib/",
   "keywords": [
     "feathers",
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jciolek/feathers-elasticsearch.git"
+    "url": "git://github.com/feathersjs/feathers-elasticsearch.git"
   },
   "author": {
     "name": "Feathers contributors",
@@ -20,7 +20,7 @@
   },
   "contributors": [],
   "bugs": {
-    "url": "https://github.com/jciolek/feathers-elasticsearch/issues"
+    "url": "https://github.com/feathersjs/feathers-elasticsearch/issues"
   },
   "engines": {
     "node": ">= 4.6.0"

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,8 @@ const queryCriteriaMap = {
   $gte: 'filter.range.gte',
   $lt: 'filter.range.lt',
   $lte: 'filter.range.lte',
-  $ne: 'must_not.term'
+  $ne: 'must_not.term',
+  $prefix: 'filter.prefix'
 };
 
 export function filter (query = {}, paginate = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,8 @@ const queryCriteriaMap = {
   $ne: 'must_not.term',
   $prefix: 'filter.prefix',
   $match: 'must.match',
-  $phrase: 'must.match_phrase'
+  $phrase: 'must.match_phrase',
+  $phrase_prefix: 'must.match_phrase_prefix'
 };
 
 export function filter (query = {}, paginate = {}) {
@@ -152,7 +153,7 @@ export function parseQuery (query, idProp) {
       // so we are most probably dealing with criteria.
       } else {
         if (isArray) {
-          throw new errors.BadRequest(`criteria should be an object or a primitive: ${key} is array`);
+          throw new errors.BadRequest(`criteria should be an object or a primitive: ${key} is an array`);
         }
 
         Object.keys(value)

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,8 @@ const queryCriteriaMap = {
   $lte: 'filter.range.lte',
   $ne: 'must_not.term',
   $prefix: 'filter.prefix',
-  $match: 'must.match'
+  $match: 'must.match',
+  $phrase: 'must.match_phrase'
 };
 
 export function filter (query = {}, paginate = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,8 @@ const queryCriteriaMap = {
   $lt: 'filter.range.lt',
   $lte: 'filter.range.lte',
   $ne: 'must_not.term',
-  $prefix: 'filter.prefix'
+  $prefix: 'filter.prefix',
+  $match: 'must.match'
 };
 
 export function filter (query = {}, paginate = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,6 +136,20 @@ export function parseQuery (query, idProp) {
         return result;
       }
 
+      if (key === '$all') {
+        if (!value) {
+          return result;
+        }
+
+        if (!result.must) {
+          result.must = [];
+        }
+
+        result.must.push({ match_all: {} });
+
+        return result;
+      }
+
       // The value is not an object, which means it's supposed to be a primitive.
       // We need add simple filter[{term: {}}] query.
       if (value === null || typeof value !== 'object') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,10 +87,12 @@ describe('Elasticsearch Service', () => {
         .then(() => {
           return app.service(serviceName).create([
             {
-              name: 'Bob'
+              name: 'Bob',
+              bio: 'I like JavaScript.'
             },
             {
-              name: 'Moody'
+              name: 'Moody',
+              bio: 'I don\'t like .NET.'
             }
           ]);
         });
@@ -126,6 +128,17 @@ describe('Elasticsearch Service', () => {
           return app.service(serviceName)
             .find({
               query: { name: { $prefix: 'B' } }
+            })
+            .then(results => {
+              expect(results.length).to.equal(1);
+              expect(results[0].name).to.equal('Bob');
+            });
+        });
+
+        it('can $match', () => {
+          return app.service(serviceName)
+            .find({
+              query: { bio: { $match: 'javascript' } }
             })
             .then(results => {
               expect(results.length).to.equal(1);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,13 +12,18 @@ import server from './test-app';
 describe('Elasticsearch Service', () => {
   const app = feathers();
   const serviceName = 'people';
-
+  const apiVersion = !process.env.ES_VERSION || process.env.ES_VERSION.split('.')[0] !== '5'
+    ? '2.4'
+    : '5.0';
+  const keywordMapping = apiVersion === '2.4'
+    ? { type: 'string', index: 'not_analyzed' }
+    : { type: 'keyword' };
   let client;
 
   before(() => {
     client = new elasticsearch.Client({
       host: 'localhost:9200',
-      apiVersion: '2.4'
+      apiVersion
     });
 
     return client.indices.exists({ index: 'test' })
@@ -29,18 +34,12 @@ describe('Elasticsearch Service', () => {
           mappings: {
             people: {
               properties: {
-                name: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                }
+                name: keywordMapping
               }
             },
             todos: {
               properties: {
-                text: {
-                  type: 'string',
-                  index: 'not_analyzed'
-                }
+                text: keywordMapping
               }
             }
           }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -137,7 +137,17 @@ describe('Elasticsearch Service', () => {
         it('can $match', () => {
           return app.service(serviceName)
             .find({
-              query: { bio: { $match: 'javascript' } }
+              query: { bio: { $match: 'I like JavaScript' } }
+            })
+            .then(results => {
+              expect(results.length).to.equal(2);
+            });
+        });
+
+        it('can $phrase', () => {
+          return app.service(serviceName)
+            .find({
+              query: { bio: { $phrase: 'I like JavaScript' } }
             })
             .then(results => {
               expect(results.length).to.equal(1);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -154,6 +154,17 @@ describe('Elasticsearch Service', () => {
               expect(results[0].name).to.equal('Bob');
             });
         });
+
+        it('can $phrase_prefix', () => {
+          return app.service(serviceName)
+            .find({
+              query: { bio: { $phrase_prefix: 'I like JavaS' } }
+            })
+            .then(results => {
+              expect(results.length).to.equal(1);
+              expect(results[0].name).to.equal('Bob');
+            });
+        });
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,6 +92,10 @@ describe('Elasticsearch Service', () => {
             {
               name: 'Moody',
               bio: 'I don\'t like .NET.'
+            },
+            {
+              name: 'Douglas',
+              bio: 'A legend'
             }
           ]);
         });
@@ -131,6 +135,16 @@ describe('Elasticsearch Service', () => {
             .then(results => {
               expect(results.length).to.equal(1);
               expect(results[0].name).to.equal('Bob');
+            });
+        });
+
+        it('can $all', () => {
+          return app.service(serviceName)
+            .find({
+              query: { $all: true }
+            })
+            .then(results => {
+              expect(results.length).to.equal(3);
             });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,6 +120,19 @@ describe('Elasticsearch Service', () => {
             expect(results.data).to.be.an('array').and.be.empty;
           });
       });
+
+      describe('special filters', () => {
+        it('can $prefix', () => {
+          return app.service(serviceName)
+            .find({
+              query: { name: { $prefix: 'B' } }
+            })
+            .then(results => {
+              expect(results.length).to.equal(1);
+              expect(results[0].name).to.equal('Bob');
+            });
+        });
+      });
     });
 
     describe('create()', () => {

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -5,10 +5,13 @@ import socketio from 'feathers-socketio';
 import bodyParser from 'body-parser';
 import service from '../lib';
 
+const apiVersion = !process.env.ES_VERSION || process.env.ES_VERSION.split('.')[0] !== '5'
+  ? '2.4'
+  : '5.0';
 // Connect to the db, create and register a Feathers service.
 const db = new elasticsearch.Client({
   host: 'localhost:9200',
-  apiVersion: '2.4'
+  apiVersion
 });
 
 const todoService = service({

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -490,6 +490,19 @@ describe('Elasticsearch utils', () => {
         .deep.equal(expectedResult);
     });
 
+    it('should return "match" query for $match', () => {
+      let query = {
+        text: { $match: 'javascript' }
+      };
+      let expectedResult = {
+        must: [
+          { match: { text: 'javascript' } }
+        ]
+      };
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
     it('should return all types of queries together', () => {
       let query = {
         $or: [
@@ -499,7 +512,8 @@ describe('Elasticsearch utils', () => {
         ],
         age: { $in: [ 12, 13 ] },
         user: 'Obi Wan',
-        country: { $nin: [ 'us', 'pl', 'ae' ] }
+        country: { $nin: [ 'us', 'pl', 'ae' ] },
+        bio: { $match: 'javascript' }
       };
       let expectedResult = {
         should: [
@@ -535,6 +549,9 @@ describe('Elasticsearch utils', () => {
         ],
         must_not: [
           { terms: { country: [ 'us', 'pl', 'ae' ] } }
+        ],
+        must: [
+          { match: { bio: 'javascript' } }
         ]
       };
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -490,6 +490,28 @@ describe('Elasticsearch utils', () => {
         .deep.equal(expectedResult);
     });
 
+    it('should return "match_all" query for $all: true', () => {
+      let query = {
+        $all: true
+      };
+      let expectedResult = {
+        must: [
+          { match_all: {} }
+        ]
+      };
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
+    it('should not return "match_all" query for $all: false', () => {
+      let query = {
+        $all: false
+      };
+      let expectedResult = null;
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
     it('should return "match" query for $match', () => {
       let query = {
         text: { $match: 'javascript' }
@@ -534,7 +556,8 @@ describe('Elasticsearch utils', () => {
         $or: [
           { likes: { $gt: 9, $lt: 12 }, age: { $ne: 10 } },
           { user: { $nin: [ 'Anakin', 'Luke' ] } },
-          { user: { $prefix: 'ada' } }
+          { user: { $prefix: 'ada' } },
+          { $all: true }
         ],
         age: { $in: [ 12, 13 ] },
         user: 'Obi Wan',
@@ -565,6 +588,13 @@ describe('Elasticsearch utils', () => {
             bool: {
               filter: [
                 { prefix: { user: 'ada' } }
+              ]
+            }
+          },
+          {
+            bool: {
+              must: [
+                { match_all: {} }
               ]
             }
           }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -516,6 +516,19 @@ describe('Elasticsearch utils', () => {
         .deep.equal(expectedResult);
     });
 
+    it('should return "match_phrase_prefix" query for $phrase_prefix', () => {
+      let query = {
+        text: { $phrase_prefix: 'javasc' }
+      };
+      let expectedResult = {
+        must: [
+          { match_phrase_prefix: { text: 'javasc' } }
+        ]
+      };
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
     it('should return all types of queries together', () => {
       let query = {
         $or: [

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -477,11 +477,25 @@ describe('Elasticsearch utils', () => {
         .deep.equal(expectedResult);
     });
 
+    it('should return "prefix" query for $prefix', () => {
+      let query = {
+        user: { $prefix: 'ada' }
+      };
+      let expectedResult = {
+        filter: [
+          { prefix: { user: 'ada' } }
+        ]
+      };
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
     it('should return all types of queries together', () => {
       let query = {
         $or: [
           { likes: { $gt: 9, $lt: 12 }, age: { $ne: 10 } },
-          { user: { $nin: [ 'Anakin', 'Luke' ] } }
+          { user: { $nin: [ 'Anakin', 'Luke' ] } },
+          { user: { $prefix: 'ada' } }
         ],
         age: { $in: [ 12, 13 ] },
         user: 'Obi Wan',
@@ -504,6 +518,13 @@ describe('Elasticsearch utils', () => {
             bool: {
               must_not: [
                 { terms: { user: [ 'Anakin', 'Luke' ] } }
+              ]
+            }
+          },
+          {
+            bool: {
+              filter: [
+                { prefix: { user: 'ada' } }
               ]
             }
           }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -503,6 +503,19 @@ describe('Elasticsearch utils', () => {
         .deep.equal(expectedResult);
     });
 
+    it('should return "match_phrase" query for $phrase', () => {
+      let query = {
+        text: { $phrase: 'javascript' }
+      };
+      let expectedResult = {
+        must: [
+          { match_phrase: { text: 'javascript' } }
+        ]
+      };
+      expect(parseQuery(query, '_id')).to
+        .deep.equal(expectedResult);
+    });
+
     it('should return all types of queries together', () => {
       let query = {
         $or: [
@@ -513,7 +526,7 @@ describe('Elasticsearch utils', () => {
         age: { $in: [ 12, 13 ] },
         user: 'Obi Wan',
         country: { $nin: [ 'us', 'pl', 'ae' ] },
-        bio: { $match: 'javascript' }
+        bio: { $match: 'javascript', $phrase: 'the good parts' }
       };
       let expectedResult = {
         should: [
@@ -551,7 +564,8 @@ describe('Elasticsearch utils', () => {
           { terms: { country: [ 'us', 'pl', 'ae' ] } }
         ],
         must: [
-          { match: { bio: 'javascript' } }
+          { match: { bio: 'javascript' } },
+          { match_phrase: { bio: 'the good parts' } }
         ]
       };
 


### PR DESCRIPTION
### Summary

This pull requests deals with #1 by enabling three full-text queries in the adapter:

- $match (Es: match)
- $phrase (Es: match_phrase)
- $phrase_prefix (Es: match_phrase_prefix)

As a bonus, there is also one term level query thrown into the mix:

- $prefix (Es: prefix)

And the simplest query there is:

- $all (Es: match_all)

The implementation is fairly simple, as the existing parser for query parameters is easily extendable. I have added relevant tests.

I did not want to introduce long query names (e.g. $match_phrase_prefix) and at the same time did not want ambiguous acronyms, so went for a compromise.

### Other Information

This PR also deals with testing the adapter on several versions of Elasticsearch. So far we had several branches, each for a different Es version. It was ok as a starting point, but quickly became cumbersome, so I have gathered all variations in one Travis config and slightly changed the test entry point as well as the test app in order to choose Es setup for 2.4 or 5.x based on env variable (ES_VERSION).

Docs [PR](https://github.com/feathersjs/feathers-docs/pull/420) already filed.