### PR TITLE
fix(eslint) minor changes to satisfy new version of semistandard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ function find (service, params) {
       size: filters.$limit,
       sort: filters.$sort,
       body: {
-        query: esQuery && { bool: esQuery } || undefined
+        query: esQuery ? { bool: esQuery } : undefined
       }
     },
     service.esParams

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,7 @@
 /* eslint-env mocha */
+// The following is required for some of the Chai's `expect` assertions,
+// e.g. expect(someVariable).to.be.empty;
+/* eslint no-unused-expressions: "off" */
 import { expect } from 'chai';
 // remember to import example as well!
 import { base, example } from 'feathers-service-tests';
@@ -278,4 +281,3 @@ describe('Elasticsearch Service', () => {
     example('_id');
   });
 });
-

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,7 @@
 /* eslint-env mocha */
+// The following is required for some of the Chai's `expect` assertions,
+// e.g. expect(someVariable).to.be.empty;
+/* eslint no-unused-expressions: "off" */
 import { expect } from 'chai';
 import { filter, mapFind, mapGet, mapPatch, mapBulk, removeProps, parseQuery } from '../src/utils';
 import { errors } from 'feathers-errors';


### PR DESCRIPTION
### Summary

During the last release (0.2.0) greenkeeper bumped up
semistandard version, and that in turn caused the release build
to fail on eslint. The main problem is with Chai's assertion like this:

`expect().to.be.empty;`

which fail on `no-unused-expressions`. It would be impractical to abandon this assertion style, so I have switched off the rule in the test scripts failing linter.
