### PR TITLE
fix(query) add minimum_should_match = 1 to the "should" query

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -132,6 +132,7 @@ export function parseQuery (query, idProp) {
           .filter(parsed => !!parsed)
           .map(parsed => ({ bool: parsed }))
         );
+        result.minimum_should_match = 1;
 
         return result;
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -182,6 +182,23 @@ describe('Elasticsearch Service', () => {
               expect(results[0].name).to.equal('Bob');
             });
         });
+
+        it('can $or correctly with other filters', () => {
+          return app.service(serviceName)
+            .find({
+              query: {
+                $or: [
+                  { name: 'Moody' },
+                  { name: 'Douglas' }
+                ],
+                bio: { $match: 'JavaScript legend' }
+              }
+            })
+            .then(result => {
+              expect(result.length).to.equal(1);
+              expect(result[0].name).to.equal('Douglas');
+            });
+        });
       });
     });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -474,7 +474,8 @@ describe('Elasticsearch utils', () => {
               ]
             }
           }
-        ]
+        ],
+        minimum_should_match: 1
       };
       expect(parseQuery(query, '_id')).to
         .deep.equal(expectedResult);
@@ -602,6 +603,7 @@ describe('Elasticsearch utils', () => {
             }
           }
         ],
+        minimum_should_match: 1,
         filter: [
           { terms: { age: [ 12, 13 ] } },
           { term: { user: 'Obi Wan' } }


### PR DESCRIPTION
### Summary

The problem appeared when the `$or` filter was used
alongside other filters (outside the `$or` group).
Expected behaviour is that at least one of the filters
in the `$or` group AND all the filters
outside the `$or` group should be met.
Elasticsearch by default returns correct results when there is only
the `$or` (Es: should) filter. However, when there are other filters
present, should seems to be ignored.

Setting `minimum_should_match = 1` fixes the problem.

### Other Information

I have added relevant test just to make sure this issues does not resurface in the future.
