### PR TITLE
export Service

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -413,3 +413,5 @@ export default function init (options) {
   debug('Initializing feathers-elasticsearch plugin');
   return new Service(options);
 }
+
+init.Service = Service;


### PR DESCRIPTION
I was adding some extra methods to by ES Service (or rather was going to) and noticed that the Service class is not exported like it is with other modules. This fixes that.

Side question: is there a reason you prefer `init.Service = Service;` over `export class Service ...`? I used the former as that is what the other repos use, but it seems the latter would be more correct.