### PR TITLE
Updated tests and operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ query: {
 ```
 
 ### $sqs
-[simple_query_string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html). A query that uses the SimpleQueryParser to parse its context. Optional `$default_operator` which is set to `or` by default but can be set to `and` if required.
+[simple_query_string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html). A query that uses the SimpleQueryParser to parse its context. Optional `$operator` which is set to `or` by default but can be set to `and` if required.
 
 ```js
 query: {
@@ -237,13 +237,13 @@ query: {
       'description'
     ],
     $query: '+like +javascript',
-    $default_operator: 'and'
+    $operator: 'and'
   }
 }
 ```
 This can also be expressed in an URL as the following:
 ```http
-http://localhost:3030/users?$sqs[$fields][]=title^5&$sqs[$fields][]=description&$sqs[$query]=+like +javascript&$sqs[$default_operator]=and
+http://localhost:3030/users?$sqs[$fields][]=title^5&$sqs[$fields][]=description&$sqs[$query]=+like +javascript&$sqs[$operator]=and
 ```
 
 ## Parent-child relationship

--- a/src/utils/parse-query.js
+++ b/src/utils/parse-query.js
@@ -73,11 +73,11 @@ function $sqs (value, esQuery, idProp) {
   }
 
   validateType(value, '$sqs', 'object');
-  validateType(value.$fields, `value.$fields`, 'array');
-  validateType(value.$query, `value.$query`, 'string');
+  validateType(value.$fields, `$sqs.$fields`, 'array');
+  validateType(value.$query, `$sqs.$query`, 'string');
 
-  if (value.$default_operator) {
-    validateType(value.$default_operator, `value.$default_operator`, 'string');
+  if (value.$operator) {
+    validateType(value.$operator, `$sqs.$operator`, 'string');
   }
 
   esQuery.must = esQuery.must || [];
@@ -85,7 +85,7 @@ function $sqs (value, esQuery, idProp) {
     simple_query_string: {
       fields: value.$fields,
       query: value.$query,
-      default_operator: value.$default_operator || 'or'
+      default_operator: value.$operator || 'or'
     }
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -271,13 +271,35 @@ describe('Elasticsearch Service', () => {
                     'name^5'
                   ],
                   $query: '+like -javascript',
-                  $default_operator: 'and'
+                  $operator: 'and'
                 }
               }
             })
             .then(results => {
               expect(results.length).to.equal(1);
               expect(results[0].name).to.equal('Moody');
+            });
+        });
+
+        it('can $sqs (simple_query_string) with other filters', () => {
+          return app.service(serviceName)
+            .find({
+              query: {
+                $sort: { name: 1 },
+                $and: [
+                  { tags: 'javascript' }
+                ],
+                $sqs: {
+                  $fields: [
+                    'bio'
+                  ],
+                  $query: '-legend'
+                }
+              }
+            })
+            .then(results => {
+              expect(results.length).to.equal(1);
+              expect(results[0].name).to.equal('Bob');
             });
         });
 


### PR DESCRIPTION
Updated the validateType error names to be inline with the object they are referencing. Changed the default_operator down to just operator to keep queries as short as possible as per @jciolek recommendation.

As per chat in PR - https://github.com/feathersjs/feathers-elasticsearch/pull/24