### PR TITLE
add raw method

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ childService.remove(
 );
 ```
 
+## Raw Queries
+Elastic Search is very powerful and sometimes the feathers interface isn't powerful enough. You can use `client.raw({})` to pass an elastic search query directly to the ES client.
+
+For examples of this power feature, please review the tests in this repo.
+
 ## Supported Elasticsearch versions
 
 feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0, 5.1, 5.2 and 5.3. Please note, event though the lowest version supported is 2.4,

--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,14 @@ class Service {
 }
 
 function raw(service, method, params) {
-  return service.Model[method](params);
+  // handle client methods like indices.create
+  const [meth, ext] = method.split('.');
+
+  if (typeof ext !== 'undefined') {
+    return service.Model[meth][ext](params);
+  }
+
+  return service.Model[meth](params);
 }
 
 function find (service, params) {

--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,17 @@ class Service {
     return removeBulk(this, params)
       .catch(errorHandler);
   }
+
+  raw (query) {
+    return raw(this, query)
+      .catch(errorHandler);
+  }
+}
+
+function raw(service, query) {
+  const method = query.method;
+  const params = query.query;
+  return service.Model[method](params);
 }
 
 function find (service, params) {

--- a/src/index.js
+++ b/src/index.js
@@ -115,15 +115,18 @@ class Service {
   }
 
   // Interface to leverage functionality provided in elasticsearchJS
-  raw (params) {
-    return raw(this, params)
+  raw (method, params) {
+    if(typeof method === 'undefined') {
+      return new Error('params.method must be defined.');
+    }
+
+    return raw(this, method, params)
       .catch(errorHandler);
   }
 }
 
-function raw(service, params) {
-  const { method, query } = params;
-  return service.Model[method](query);
+function raw(service, method, params) {
+  return service.Model[method](params);
 }
 
 function find (service, params) {

--- a/src/index.js
+++ b/src/index.js
@@ -114,16 +114,16 @@ class Service {
       .catch(errorHandler);
   }
 
-  raw (query) {
-    return raw(this, query)
+  // Interface to leverage functionality provided in elasticsearchJS
+  raw (params) {
+    return raw(this, params)
       .catch(errorHandler);
   }
 }
 
-function raw(service, query) {
-  const method = query.method;
-  const params = query.query;
-  return service.Model[method](params);
+function raw(service, params) {
+  const { method, query } = params;
+  return service.Model[method](query);
 }
 
 function find (service, params) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -537,6 +537,48 @@ describe('Elasticsearch Service', () => {
           });
       });
     });
+
+    describe('raw()', () => {
+      it('should search documents in index with syntax term', () => {
+        return app.service('mobiles')
+          .raw('search', {
+            size: 50,
+            body: {
+              query: {
+                term: {
+                  name: 'Bob'
+                }
+              }
+            }
+          }).then(results => {
+            expect(results.hits.hits.length).to.equal(2);
+          });
+      });
+
+      it('should search documents in index with syntax match', () => {
+        return app.service('mobiles')
+          .raw('search', {
+            size: 50,
+            body: {
+              query: {
+                match: {
+                  bio: 'javascript'
+                }
+              }
+            }
+          }).then(results => {
+            expect(results.hits.hits.length).to.equal(1);
+          });
+      });
+
+      it('should show the mapping of index test', () => {
+        return app.service('mobiles')
+          .raw('indices.getMapping', {})
+          .then(results => {
+            expect(results.test.mappings.mobiles._parent.type).to.equal('people');
+          });
+      })
+    });
   });
 
   describe('Elasticsearch service example test', () => {


### PR DESCRIPTION
Overview
---
A lot of elastic search functionality in elasticsearch.js are not supported through the current static query types, so this PR exposes a raw method that allows you to send any ES query directly.

Added functionalities
---
- [x] Wrote a raw function to expose elastic search abundant methods. Usage: 
```
service.raw('method', {params})
```
Here you can use `params` exactly as how you use in elasticsearch.js.
- [x] Wrote tests for this raw methods.

---
Please let me know if there are any changes you would like to make, otherwise, this would probably be best published as `0.4.0` but you could argue `0.3.2` as well. Please tag me after published to npm. Thanks for the great work on feathers!