### PR TITLE
make raw method robuster

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,8 @@ class Service {
   // Interface to leverage functionality provided in elasticsearchJS
   raw (method, params) {
     if(typeof method === 'undefined') {
-      return new Error('params.method must be defined.');
+      return Promise
+        .reject(new Error('params.method must be defined.'));
     }
 
     return raw(this, method, params)


### PR DESCRIPTION
overview
---
- [x] when one calls `raw(method, query)` with method undefined, it's supposed to return a rejected promise;
- [x] when one calls `raw(method, query)` with query method not a function, it's supposed to return a rejected promise; 
- [x] otherwise, it's supposed to return the correct result. 

issue 
---
When I `git clone`, `npm install` and `npm test`, it always fails. I don't figure out what happened there... 

version 
--- 
Since this is a minor change, I would suggest it as 0.4.1. @slajax @daffl Would you please take a look at this? Please let me if it has any problem. Thank you. 